### PR TITLE
Document postgresHost and postgresExternalName

### DIFF
--- a/helm/ffc-demo-claim-service/development-values.yaml
+++ b/helm/ffc-demo-claim-service/development-values.yaml
@@ -3,4 +3,3 @@ container:
   args: ["scripts/wait-for/wait-for $(POSTGRES_HOST):5432 -- npm --no-update-notifier run migrate && node index"]
   messageQueueHost: ffc-demo-claim-artemis-activemq-artemis
 postgresHost: ffc-demo-claim-postgres-postgresql
-postgresExternalName:

--- a/helm/ffc-demo-claim-service/values.yaml
+++ b/helm/ffc-demo-claim-service/values.yaml
@@ -2,7 +2,11 @@ environment: development
 postgresUsername: postgres@mine-support2
 postgresPassword: changeme
 postgresDatabase: mine_claims
+# postgresHost is the host name of the PostgreSQL service
 postgresHost: ffc-demo-claims-postgres
+# postgresExternalName is the external host name to which PostgreSQL
+# requests should be forwarded. If empty, PostgreSQL is assumed to be
+# within the cluster and accessible via postgresHost
 postgresExternalName: host.docker.internal
 postgresPort: 5432
 name: ffc-demo-claim-service

--- a/helm/ffc-demo-claim-service/values.yaml
+++ b/helm/ffc-demo-claim-service/values.yaml
@@ -7,7 +7,7 @@ postgresHost: ffc-demo-claims-postgres
 # postgresExternalName is the external host name to which PostgreSQL
 # requests should be forwarded. If empty, PostgreSQL is assumed to be
 # within the cluster and accessible via postgresHost
-postgresExternalName: host.docker.internal
+postgresExternalName:
 postgresPort: 5432
 name: ffc-demo-claim-service
 image: ffc-demo-claim-service


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-227

These two variables have caused confusion. Values should be documented
in values.yaml, as per official Helm best practices.