### PR TITLE
PSD-529 Update kubernetes resources to specify namespace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-library@2.0.0')
+@Library('defra-library@3.0.0')
 import uk.gov.defra.ffc.DefraUtils
 def defraUtils = new DefraUtils()
 

--- a/helm/ffc-demo-claim-service/jenkins-aws.yaml
+++ b/helm/ffc-demo-claim-service/jenkins-aws.yaml
@@ -1,4 +1,5 @@
 name: ffc-demo-claim-service
+namespace: ffc-demo
 imagePullSecret: myregistrykey
 container:
   allowPrivilegeEscalation: true

--- a/helm/ffc-demo-claim-service/templates/deployment.yaml
+++ b/helm/ffc-demo-claim-service/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ quote .Values.name }}
+  namespace: {{ quote .Values.namespace }}
 spec:
   replicas: {{ .Values.replicaCount }}
   minReadySeconds: {{ .Values.minReadySeconds }}

--- a/helm/ffc-demo-claim-service/templates/service.yaml
+++ b/helm/ffc-demo-claim-service/templates/service.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ quote .Values.name }}
+  namespace: {{ quote .Values.namespace }}
   labels:
     app: {{ quote .Values.name }}
 spec:

--- a/helm/ffc-demo-claim-service/templates/service.yaml
+++ b/helm/ffc-demo-claim-service/templates/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ quote .Values.postgresHost }}
+  namespace: {{ quote .Values.namespace }}
 spec:
   type: ExternalName
   externalName: {{ quote .Values.postgresExternalName }}

--- a/helm/ffc-demo-claim-service/values.yaml
+++ b/helm/ffc-demo-claim-service/values.yaml
@@ -10,6 +10,7 @@ postgresHost: ffc-demo-claims-postgres
 postgresExternalName:
 postgresPort: 5432
 name: ffc-demo-claim-service
+namespace: ffc-demo
 image: ffc-demo-claim-service
 imagePullSecret:
 service:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-demo-claim-service",
   "description": "Digital service mock to claim public money in the event property subsides into mine shaft.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "homepage": "https://github.com/DEFRA/mine-support-claim-service",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-demo-claim-service",
   "description": "Digital service mock to claim public money in the event property subsides into mine shaft.",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "homepage": "https://github.com/DEFRA/mine-support-claim-service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-529

Updating kubernetes resources to specify namespace, as Helm 3 doesn't have the --namespace switch in the upgrade command