### PR TITLE
priorityClassName specified in the wrong place

### DIFF
--- a/helm/ffc-demo-claim-service/templates/deployment.yaml
+++ b/helm/ffc-demo-claim-service/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ quote .Values.namespace }}
   labels: {{ include "ffc-demo.labels" . | trimSuffix "\n" | indent 2 }}
 spec:
-  priorityClassName: {{ quote .Values.container.priorityClassName }}
   replicas: {{ .Values.replicaCount }}
   minReadySeconds: {{ .Values.minReadySeconds }}
   selector:
@@ -24,6 +23,7 @@ spec:
       annotations:
         redeployOnChange: {{ quote .Values.container.redeployOnChange }}
     spec:
+      priorityClassName: {{ quote .Values.container.priorityClassName }}
 {{- if .Values.serviceAccount.roleArn }}
       serviceAccountName: {{ quote .Values.serviceAccount.name }}
 {{- end }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-demo-claim-service",
   "description": "Digital service mock to claim public money in the event property subsides into mine shaft.",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "homepage": "https://github.com/DEFRA/mine-support-claim-service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Helm 3 has highlighed an issue where priorityClassName is specified in
the spec of the deployment rather than the pod further down.