### PR TITLE
Ensure health check endpoint contain error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-demo-claim-service",
   "description": "Digital service mock to claim public money in the event property subsides into mine shaft.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "homepage": "https://github.com/DEFRA/mine-support-claim-service",
   "main": "index.js",
   "scripts": {

--- a/server/routes/healthy.js
+++ b/server/routes/healthy.js
@@ -14,7 +14,8 @@ module.exports = {
         }
         return h.response('database unavailable').code(SERVICE_UNAVAILABLE)
       } catch (ex) {
-        return h.response(`Error checking database health: ${ex.message}`).code(SERVICE_UNAVAILABLE)
+        console.error('error running healthy check', ex)
+        return h.response(`error running healthy check: ${ex.message}`).code(SERVICE_UNAVAILABLE)
       }
     }
   }

--- a/server/routes/healthy.js
+++ b/server/routes/healthy.js
@@ -1,14 +1,21 @@
 const databaseService = require('../services/database-service')
 
+const SERVICE_UNAVAILABLE = 503
+const OK = 200
+
 module.exports = {
   method: 'GET',
   path: '/healthy',
   options: {
     handler: async (request, h) => {
-      if (await databaseService.isConnected()) {
-        return h.response('ok').code(200)
+      try {
+        if (await databaseService.isConnected()) {
+          return h.response('ok').code(OK)
+        }
+        return h.response('database unavailable').code(SERVICE_UNAVAILABLE)
+      } catch (ex) {
+        return h.response(`Error checking database health: ${ex.message}`).code(SERVICE_UNAVAILABLE)
       }
-      return h.response('database unavailable').code(503)
     }
   }
 }

--- a/test/routes/healthy.test.js
+++ b/test/routes/healthy.test.js
@@ -16,7 +16,6 @@ describe('Healthy test', () => {
       method: 'GET',
       url: '/healthy'
     }
-
     databaseService.isConnected.mockReturnValue(true)
 
     const response = await server.inject(options)
@@ -24,7 +23,7 @@ describe('Healthy test', () => {
     expect(response.statusCode).toBe(200)
   })
 
-  test('GET /healthy returns 500 if database not connected', async () => {
+  test('GET /healthy returns 503 if database not connected', async () => {
     const options = {
       method: 'GET',
       url: '/healthy'
@@ -38,7 +37,27 @@ describe('Healthy test', () => {
     expect(response.payload).toBe('database unavailable')
   })
 
+  test('GET /healthy returns 503 and error message if database check throws an error', async () => {
+    const options = {
+      method: 'GET',
+      url: '/healthy'
+    }
+
+    const errorMessage = 'database connection timeout'
+    databaseService.isConnected.mockImplementation(() => { throw new Error(errorMessage) })
+
+    const response = await server.inject(options)
+
+    expect(response.statusCode).toBe(503)
+    expect(response.payload).toBe(`error running healthy check: ${errorMessage}`)
+  })
+
   afterEach(async () => {
     await server.stop()
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
   })
 })

--- a/test/routes/healthy.test.js
+++ b/test/routes/healthy.test.js
@@ -1,26 +1,10 @@
 describe('Healthy test', () => {
-  const calculationSender = {}
-  let createServer
-  let databaseService
-  let messageService
-  const scheduleSender = {}
   let server
 
-  beforeAll(async () => {
-    jest.mock('../../server/services/database-service')
-    jest.mock('../../server/services/message-service')
-
-    databaseService = require('../../server/services/database-service')
-    messageService = require('../../server/services/message-service')
-
-    messageService.getCalculationSender = jest.fn().mockReturnValue(calculationSender)
-    messageService.getScheduleSender = jest.fn().mockReturnValue(scheduleSender)
-
-    calculationSender.isConnected = jest.fn().mockReturnValue(false)
-    scheduleSender.isConnected = jest.fn().mockReturnValue(false)
-
-    createServer = require('../../server')
-  })
+  jest.mock('../../server/services/message-service')
+  jest.mock('../../server/services/database-service')
+  const databaseService = require('../../server/services/database-service')
+  const createServer = require('../../server')
 
   beforeEach(async () => {
     server = await createServer()
@@ -33,9 +17,7 @@ describe('Healthy test', () => {
       url: '/healthy'
     }
 
-    databaseService.isConnected = jest.fn().mockReturnValue(true)
-    calculationSender.isConnected = jest.fn().mockReturnValue(true)
-    scheduleSender.isConnected = jest.fn().mockReturnValue(true)
+    databaseService.isConnected.mockReturnValue(true)
 
     const response = await server.inject(options)
 
@@ -48,57 +30,7 @@ describe('Healthy test', () => {
       url: '/healthy'
     }
 
-    databaseService.isConnected = jest.fn().mockReturnValue(false)
-    calculationSender.isConnected = jest.fn().mockReturnValue(true)
-    scheduleSender.isConnected = jest.fn().mockReturnValue(true)
-
-    const response = await server.inject(options)
-
-    expect(response.statusCode).toBe(503)
-    expect(response.payload).toBe('database unavailable')
-  })
-
-  test('GET /healthy returns 503 if calculation queue not connected', async () => {
-    const options = {
-      method: 'GET',
-      url: '/healthy'
-    }
-
-    databaseService.isConnected = jest.fn().mockReturnValue(true)
-    calculationSender.isConnected = jest.fn().mockReturnValue(false)
-    scheduleSender.isConnected = jest.fn().mockReturnValue(true)
-
-    const response = await server.inject(options)
-
-    expect(response.statusCode).toBe(200)
-    expect(response.payload).toBe('ok')
-  })
-
-  test('GET /healthy returns 503 if schedule queue not connected', async () => {
-    const options = {
-      method: 'GET',
-      url: '/healthy'
-    }
-
-    databaseService.isConnected = jest.fn().mockReturnValue(true)
-    calculationSender.isConnected = jest.fn().mockReturnValue(true)
-    scheduleSender.isConnected = jest.fn().mockReturnValue(false)
-
-    const response = await server.inject(options)
-
-    expect(response.statusCode).toBe(200)
-    expect(response.payload).toBe('ok')
-  })
-
-  test('GET /healthy returns 503 with appropriate message if all downstream services are disconnected', async () => {
-    const options = {
-      method: 'GET',
-      url: '/healthy'
-    }
-
-    databaseService.isConnected = jest.fn().mockReturnValue(false)
-    calculationSender.isConnected = jest.fn().mockReturnValue(false)
-    scheduleSender.isConnected = jest.fn().mockReturnValue(false)
+    databaseService.isConnected.mockReturnValue(false)
 
     const response = await server.inject(options)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-318

Uncaught errors in the health check endpoint can make it difficult to
see what is unhealthy. The end point should handle the error and provide
details, along with the error message