### PR TITLE
295886: Add ffc-demo-claim-service-pre1 variable group ref

### DIFF
--- a/.azuredevops/build.yaml
+++ b/.azuredevops/build.yaml
@@ -61,5 +61,6 @@ extends:
         - ffc-demo-claim-service-snd3
         - ffc-demo-claim-service-dev1
         - ffc-demo-claim-service-tst1
+        - ffc-demo-claim-service-pre1
       variables:
         - ffc-demo-claim-service-notify-api-key

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-demo-claim-service",
-  "version": "5.1.29",
+  "version": "5.1.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-demo-claim-service",
-      "version": "5.1.29",
+      "version": "5.1.30",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-demo-claim-service",
   "description": "Digital service mock to claim public money in the event property subsides into mine shaft.",
-  "version": "5.1.29",
+  "version": "5.1.30",
   "homepage": "https://github.com/DEFRA/mine-support-claim-service",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
As part of the trial ADP PRE deployment we noticed the variable group refs were missing from the application pipeline.  This PR adds the variable group reference.